### PR TITLE
Add Telegram ChatGPT bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gpt1
 
-This repository contains a simple Telegram bot that forwards user messages to the OpenAI ChatGPT API. The bot behaves like a digital twin of your ChatGPT profile.
+This repository contains a simple Telegram bot that forwards user messages to the OpenAI ChatGPT API. The bot behaves like a digital twin of your ChatGPT profile and remembers each user's conversation.
 
 ## Setup
 
@@ -17,4 +17,4 @@ This repository contains a simple Telegram bot that forwards user messages to th
    python bot.py
    ```
 
-The bot listens for messages and replies using ChatGPT.
+The bot listens for messages and replies using ChatGPT. Each chat maintains its own history so the responses stay in context.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ This repository contains a simple Telegram bot that forwards user messages to th
    ```
 
 The bot listens for messages and replies using ChatGPT. Each chat maintains its own history so the responses stay in context.
+
+## Troubleshooting
+If you see a `SyntaxError` mentioning lines like `index 000000...` when running `bot.py`,
+you may have copied diff markers instead of the actual code. Download the raw
+`bot.py` file from this repository to avoid that issue.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # gpt1
+
+This repository contains a simple Telegram bot that forwards user messages to the OpenAI ChatGPT API. The bot behaves like a digital twin of your ChatGPT profile.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set the following environment variables with your credentials:
+   - `TELEGRAM_BOT_TOKEN` – token for your Telegram bot
+   - `OPENAI_API_KEY` – API key for OpenAI
+
+3. Run the bot:
+   ```bash
+   python bot.py
+   ```
+
+The bot listens for messages and replies using ChatGPT.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,37 @@
+import os
+from telegram import Update
+from telegram.ext import ApplicationBuilder, CommandHandler, MessageHandler, ContextTypes, filters
+import openai
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+
+openai.api_key = OPENAI_API_KEY
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send a greeting message."""
+    await update.message.reply_text("Hello! I'm your digital twin. Ask me anything.")
+
+async def respond(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Forward the user's message to OpenAI and send back the response."""
+    user_message = update.message.text
+    try:
+        completion = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": user_message}],
+        )
+        reply = completion.choices[0].message.content
+    except Exception as exc:
+        reply = f"Error: {exc}"
+    await update.message.reply_text(reply)
+
+def main() -> None:
+    if not TELEGRAM_BOT_TOKEN or not OPENAI_API_KEY:
+        raise EnvironmentError("Missing TELEGRAM_BOT_TOKEN or OPENAI_API_KEY")
+    app = ApplicationBuilder().token(TELEGRAM_BOT_TOKEN).build()
+    app.add_handler(CommandHandler("start", start))
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, respond))
+    app.run_polling()
+
+if __name__ == "__main__":
+    main()

--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,12 @@
 import os
 from telegram import Update
-from telegram.ext import ApplicationBuilder, CommandHandler, MessageHandler, ContextTypes, filters
+from telegram.ext import (
+    ApplicationBuilder,
+    CommandHandler,
+    MessageHandler,
+    ContextTypes,
+    filters,
+)
 import openai
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -8,19 +14,36 @@ TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 
 openai.api_key = OPENAI_API_KEY
 
+# Keep conversation history per user
+conversations = {}
+
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Send a greeting message."""
-    await update.message.reply_text("Hello! I'm your digital twin. Ask me anything.")
+    await update.message.reply_text(
+        "Hello! I'm your ChatGPT twin. Send me a message and I'll respond."
+    )
 
 async def respond(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Forward the user's message to OpenAI and send back the response."""
-    user_message = update.message.text
+    user_id = update.effective_user.id
+    history = conversations.setdefault(
+        user_id,
+        [
+            {
+                "role": "system",
+                "content": "You are a digital twin of the user's ChatGPT profile.",
+            }
+        ],
+    )
+    history.append({"role": "user", "content": update.message.text})
+
     try:
         completion = openai.ChatCompletion.create(
             model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": user_message}],
+            messages=history,
         )
         reply = completion.choices[0].message.content
+        history.append({"role": "assistant", "content": reply})
     except Exception as exc:
         reply = f"Error: {exc}"
     await update.message.reply_text(reply)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-telegram-bot>=20.0
+openai>=1.0


### PR DESCRIPTION
## Summary
- implement `bot.py` with a Telegram bot that forwards messages to OpenAI
- document setup in `README.md`
- declare Python dependencies in `requirements.txt`

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_683f614c28a8832db1ad99d12b8d64ab

## Summary by Sourcery

Add a standalone Telegram ChatGPT bot with dependency declarations and setup documentation

New Features:
- Add a Telegram bot that relays user messages to OpenAI ChatGPT and returns responses

Build:
- Declare python-telegram-bot and OpenAI client dependencies in requirements.txt

Documentation:
- Include setup instructions and environment variable configuration in README